### PR TITLE
stop silent delete failures in main.go and add k6 upload/delete cycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ Thumbs.db
 .env
 terraform.*.bin/
 .bin/
+
+test.txt
+server.test
+server/server

--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ In test directory:
     K6_WEB_DASHBOARD=true K6_WEB_DASHBOARD_EXPORT=dashboard_report.html k6 run neudfs_test.js
     open dashboard_report.html
     open neudfs_report.html
+
+

--- a/k6/load_test.js
+++ b/k6/load_test.js
@@ -1,6 +1,7 @@
 import grpc from 'k6/net/grpc';
 import { check, sleep, group } from 'k6';
 import { Counter, Trend, Rate } from 'k6/metrics';
+import exec from 'k6/execution';
 
 const client = new grpc.Client();
 client.load(['../proto'], 'server.proto');
@@ -69,7 +70,7 @@ export const options = {
     },
     teacher_race: {
       executor: 'per-vu-iterations',
-      vus: 1,
+      vus: 5,
       iterations: 1,
       startTime: '7m10s',
       exec: 'teacherUpdateRace',
@@ -274,12 +275,30 @@ function uploadBytes(email, filename, data) {
   return success;
 }
 
+// Each scenario gets a different starting offset so VU 1 in two concurrent
+// scenarios doesn't hash to the same student and stack uploads on one user.
+// Stride of 7 (prime) avoids alignment even for small STUDENTS arrays.
+const SCENARIO_STUDENT_OFFSET = {
+  steady_classroom:           0,
+  burst_download:             7,
+  integrity_check:            14,
+  upload_delete_cycle:        21,
+  large_file:                 28,
+  rapid_fire:                 35,
+  spike_test:                 42,
+  soak_test:                  49,
+  tree_stress:                56,
+  session_conflict_upload:    63,
+  session_conflict_navigate:  70,
+};
+
 function getStudentEmail() {
-  return STUDENTS[(__VU - 1) % STUDENTS.length];
+  const offset = SCENARIO_STUDENT_OFFSET[exec.scenario.name] || 0;
+  return STUDENTS[(__VU - 1 + offset) % STUDENTS.length];
 }
 
 function getStudentFolder(email) {
-  return email.split('@')[0].replace('.', '_');
+  return email.split('@')[0].replace(/\./g, '_');
 }
 
 export function seedTestData() {
@@ -378,6 +397,11 @@ export function studentWorkflow() {
   group('download', () => {
     timedInvoke(downloadLatency, 'main.Server/Download',
       { name: `hw_${__VU}_${__ITER}.txt` }, email);
+  });
+
+  group('cleanup', () => {
+    client.invoke('main.Server/Delete',
+      { path: `hw_${__VU}_${__ITER}.txt` }, meta(email));
   });
 
   sleep(Math.random() * 2 + 1);
@@ -521,7 +545,7 @@ export function uploadDeleteWorkflow() {
 
   group('post-delete download', () => {
     const resp = client.invoke('main.Server/Download', { name: filename }, meta(email));
-    const blocked = !resp || resp.status === grpc.StatusNotFound;
+    const blocked = !resp || resp.status !== grpc.StatusOK;
     check(blocked, { 'post-delete download not found': (v) => v === true });
     if (!blocked) {
       rpcErrors.add(1);
@@ -536,21 +560,42 @@ export function teacherUpdateRace() {
   connect();
   navigate(PROFESSOR, ['Khoury', 'CS5010', 'announcements']);
 
-  const data = new Uint8Array(10240);
-  uploadBytes(PROFESSOR, 'race_file.txt', data);
+  // Each VU uploads a distinct version of the same file concurrently.
+  // With vus:5, all five uploads race against each other on S3 + DynamoDB.
+  // One write wins; the others overwrite it — last writer wins on S3.
+  const vData = new Uint8Array(10240);
+  vData.fill(__VU); // distinct byte pattern per VU so we can tell who won
+  const uploadOk = uploadBytes(PROFESSOR, 'race_file.txt', vData);
+  check(uploadOk, { 'concurrent upload completed': (v) => v === true });
 
-  for (let v = 2; v <= 5; v++) {
-    const vData = new Uint8Array(10240);
-    vData.fill(v + 48);
-    uploadBytes(PROFESSOR, 'race_file.txt', vData);
-    sleep(0.3);
+  // After all VUs finish uploading, verify the file is in a readable, complete state.
+  // Any version is valid — what must NOT happen is a partial or corrupt result.
+  const resp = client.invoke('main.Server/Download',
+    { name: 'race_file.txt' }, meta(PROFESSOR));
+  check(resp, { 'race file readable after concurrent uploads': (r) => r && r.status === grpc.StatusOK });
+  if (resp && resp.status === grpc.StatusOK) {
+    const data = resp.message && resp.message.data;
+    check(data, { 'race file has full content': (d) => d && d.length === 10240 });
+    if (data && data.length === 10240) {
+      // All bytes should be the same value (one VU's fill won cleanly, not a mix)
+      const firstByte = data[0];
+      let corrupt = false;
+      for (let i = 1; i < data.length; i++) {
+        if (data[i] !== firstByte) { corrupt = true; break; }
+      }
+      check(!corrupt, { 'race file not corrupted (single winner)': (v) => v === true });
+      if (corrupt) integrityFailures.add(1);
+    }
   }
 
-  const start = Date.now();
-  const resp = client.invoke('main.Server/Delete',
-    { path: 'race_file.txt' }, meta(PROFESSOR));
-  deleteLatency.add(Date.now() - start);
-  check(resp, { 'race delete ok': (r) => r && r.status === grpc.StatusOK });
+  // Only VU 1 deletes to avoid a delete race on top of the upload race.
+  if (__VU === 1) {
+    const start = Date.now();
+    const delResp = client.invoke('main.Server/Delete',
+      { path: 'race_file.txt' }, meta(PROFESSOR));
+    deleteLatency.add(Date.now() - start);
+    check(delResp, { 'race delete ok': (r) => r && r.status === grpc.StatusOK });
+  }
 
   client.close();
 }
@@ -758,6 +803,7 @@ export function soakWorkflow() {
 export function treeStress() {
   connect();
   const email = getStudentEmail();
+  const folder = getStudentFolder(email);
 
   group('tree from root', () => {
     navigate(email, []);
@@ -772,6 +818,18 @@ export function treeStress() {
   group('tree from class', () => {
     navigate(email, ['Khoury', 'CS5010']);
     timedInvoke(treeLatency, 'main.Server/TreeDirectory', {}, email);
+  });
+
+  // Clean up any hw_* files left behind by studentWorkflow runs for this VU.
+  // Navigate to the student's folder and delete files for all iterations seen.
+  group('cleanup stale hw files', () => {
+    if (!navigate(email, ['Khoury', 'CS5010', folder])) return;
+    for (let iter = 0; iter < 200; iter++) {
+      const resp = client.invoke('main.Server/Delete',
+        { path: `hw_${__VU}_${iter}.txt` }, meta(email));
+      // Stop once we hit a run of NotFound — no more files for this VU
+      if (!resp || resp.status === grpc.StatusNotFound) break;
+    }
   });
 
   client.close();
@@ -980,6 +1038,7 @@ export function renameFileWorkflow(){
             }
         }
     })
+    client.close();
 }
 
 export function concurrentRenameStress() {

--- a/k6/load_test.js
+++ b/k6/load_test.js
@@ -59,6 +59,14 @@ export const options = {
       exec: 'integrityCheck',
       tags: { scenario: 'integrity' },
     },
+    upload_delete_cycle: {
+      executor: 'per-vu-iterations',
+      vus: 10,
+      iterations: 3,
+      startTime: '6m50s',
+      exec: 'uploadDeleteWorkflow',
+      tags: { scenario: 'upload_delete_cycle' },
+    },
     teacher_race: {
       executor: 'per-vu-iterations',
       vus: 1,
@@ -434,6 +442,93 @@ export function integrityCheck() {
   });
 
   client.invoke('main.Server/Delete', { path: filename }, meta(email));
+  client.close();
+}
+
+export function uploadDeleteWorkflow() {
+  connect();
+  const email = getStudentEmail();
+  const folder = getStudentFolder(email);
+  navigate(email, ['Khoury', 'CS5010', folder]);
+
+  const data = new Uint8Array(4096);
+  for (let i = 0; i < data.length; i++) {
+    data[i] = (i * 17) % 256;
+  }
+  const filename = `cycle_${__VU}_${__ITER}.bin`;
+  let failed = false;
+
+  group('upload', () => {
+    const ok = uploadBytes(email, filename, data);
+    check(ok, { 'cycle upload ok': (v) => v === true });
+    if (!ok) {
+      failed = true;
+    }
+  });
+  if (failed) {
+    client.close();
+    return;
+  }
+
+  group('download', () => {
+    const start = Date.now();
+    const resp = client.invoke('main.Server/Download', { name: filename }, meta(email));
+    downloadLatency.add(Date.now() - start);
+    check(resp, { 'cycle download ok': (r) => r && r.status === grpc.StatusOK });
+    if (!resp || resp.status !== grpc.StatusOK) {
+      rpcErrors.add(1);
+      failed = true;
+      return;
+    }
+
+    const downloaded = resp.message.data;
+    const sameLength = downloaded && downloaded.length === data.length;
+    check(downloaded, { 'cycle download has data': (v) => v && v.length === data.length });
+    if (!sameLength) {
+      rpcErrors.add(1);
+      console.error(`cycle size mismatch for ${filename}`);
+      failed = true;
+      return;
+    }
+    for (let i = 0; i < data.length; i++) {
+      if (downloaded[i] !== data[i]) {
+        rpcErrors.add(1);
+        console.error(`cycle byte mismatch at ${i} for ${filename}`);
+        failed = true;
+        return;
+      }
+    }
+  });
+  if (failed) {
+    client.close();
+    return;
+  }
+
+  group('delete', () => {
+    const start = Date.now();
+    const resp = client.invoke('main.Server/Delete', { path: filename }, meta(email));
+    deleteLatency.add(Date.now() - start);
+    check(resp, { 'cycle delete ok': (r) => r && r.status === grpc.StatusOK });
+    if (!resp || resp.status !== grpc.StatusOK) {
+      rpcErrors.add(1);
+      failed = true;
+    }
+  });
+  if (failed) {
+    client.close();
+    return;
+  }
+
+  group('post-delete download', () => {
+    const resp = client.invoke('main.Server/Download', { name: filename }, meta(email));
+    const blocked = !resp || resp.status === grpc.StatusNotFound;
+    check(blocked, { 'post-delete download not found': (v) => v === true });
+    if (!blocked) {
+      rpcErrors.add(1);
+      console.error(`SECURITY: ${email} downloaded ${filename} after delete`);
+    }
+  });
+
   client.close();
 }
 

--- a/k6/students.json
+++ b/k6/students.json
@@ -1,12 +1,12 @@
 [
-    "ruby.williams@northeastern.edu",
-    "charlie.johnson@northeastern.edu",
-    "olivia.williams@northeastern.edu",
-    "bob.jackson@northeastern.edu",
-    "grace.taylor@northeastern.edu",
-    "bella.miller@northeastern.edu",
-    "victor.wilson@northeastern.edu",
-    "wendy.jones@northeastern.edu",
-    "uma.williams@northeastern.edu",
-    "sam.lewis@northeastern.edu"
+    "mia.martin@northeastern.edu",
+    "ruby.clark@northeastern.edu",
+    "bob.miller@northeastern.edu",
+    "alice.anderson@northeastern.edu",
+    "zach.moore@northeastern.edu",
+    "karen.jones@northeastern.edu",
+    "daisy.wilson@northeastern.edu",
+    "xander.wilson@northeastern.edu",
+    "charlie.thomas@northeastern.edu",
+    "jack.anderson@northeastern.edu"
 ]

--- a/server/cloudwatch.go
+++ b/server/cloudwatch.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -113,6 +114,15 @@ func logRPCMetric(method, email, code string, duration time.Duration) {
 	fmt.Println(string(data))
 }
 
+func emailFromContext(ctx context.Context) string {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if emails := md["email"]; len(emails) > 0 {
+			return emails[0]
+		}
+	}
+	return ""
+}
+
 func cloudwatchUnaryInterceptor(cwm *CloudWatchMetrics, inner grpc.UnaryServerInterceptor) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		start := time.Now()
@@ -124,10 +134,7 @@ func cloudwatchUnaryInterceptor(cwm *CloudWatchMetrics, inner grpc.UnaryServerIn
 				code = st.Code().String()
 			}
 		}
-		email := ""
-		if user, ok := ctx.Value("User").(User); ok {
-			email = user.Email
-		}
+		email := emailFromContext(ctx)
 		cwm.Record(info.FullMethod, email, code, duration)
 		logRPCMetric(info.FullMethod, email, code, duration)
 
@@ -146,11 +153,7 @@ func cloudwatchStreamInterceptor(cwm *CloudWatchMetrics, inner grpc.StreamServer
 				code = st.Code().String()
 			}
 		}
-		ctx := ss.Context()
-		email := ""
-		if user, ok := ctx.Value("User").(User); ok {
-			email = user.Email
-		}
+		email := emailFromContext(ss.Context())
 		cwm.Record(info.FullMethod, email, code, duration)
 		logRPCMetric(info.FullMethod, email, code, duration)
 

--- a/server/main.go
+++ b/server/main.go
@@ -1022,6 +1022,7 @@ func (s *server) Delete(ctx context.Context, in *proto.DeleteRequest) (*proto.De
 		s3Key := collegeName + "/" + className + "/" + targetSK
 		if err := s.DeleteS3File(ctx, s3Key); err != nil {
 			logger("Failed to delete S3 file %s: %v", s3Key, err)
+			return nil, errDB
 		}
 		_, err = s.DB.DeleteItem(ctx, &dynamodb.DeleteItemInput{
 			TableName: aws.String(metadataTable),
@@ -1061,12 +1062,13 @@ func (s *server) Delete(ctx context.Context, in *proto.DeleteRequest) (*proto.De
 		var meta Metadata
 		if err := attributevalue.UnmarshalMap(item, &meta); err != nil {
 			logger("Failed to unmarshal item: %v", err)
-			continue
+			return nil, errDB
 		}
 		if meta.Type == "file" {
 			s3Key := collegeName + "/" + className + "/" + meta.SK
 			if err := s.DeleteS3File(ctx, s3Key); err != nil {
 				logger("Failed to delete S3 file %s: %v", s3Key, err)
+				return nil, errDB
 			}
 		}
 		_, err = s.DB.DeleteItem(ctx, &dynamodb.DeleteItemInput{
@@ -1078,11 +1080,15 @@ func (s *server) Delete(ctx context.Context, in *proto.DeleteRequest) (*proto.De
 		})
 		if err != nil {
 			logger("Failed to delete item %s: %v", meta.SK, err)
+			return nil, errDB
 		}
 	}
 
 	// Remove deleted folder and its subfolders from permission arrays
-	s.removeFolderFromLists(ctx, collegeName, className, targetSK)
+	if err := s.removeFolderFromLists(ctx, collegeName, className, targetSK); err != nil {
+		logger("Failed to update folder permissions after delete: %v", err)
+		return nil, errDB
+	}
 
 	return &proto.DeleteResponse{Message: fmt.Sprintf("Deleted folder %s", targetName)}, nil
 }

--- a/server/main.go
+++ b/server/main.go
@@ -898,21 +898,32 @@ func (s *server) Upload(stream proto.Server_UploadServer) error {
 			break
 		}
 		if err != nil {
-			mp.Abort(ctx)
+			abortCtx, abortCancel := context.WithTimeout(context.Background(), 15*time.Second)
+			mp.Abort(abortCtx)
+			abortCancel()
 			return status.Errorf(codes.Internal, "error receiving chunk")
 		}
 		if chunk := req.GetChunk(); len(chunk) > 0 {
 			if err := mp.Write(ctx, chunk); err != nil {
-				mp.Abort(ctx)
+				abortCtx, abortCancel := context.WithTimeout(context.Background(), 15*time.Second)
+				mp.Abort(abortCtx)
+				abortCancel()
 				logger("Failed to upload part: %v", err)
 				return status.Errorf(codes.Internal, "failed to upload file part")
 			}
 		}
 	}
 
-	url, err := mp.Complete(ctx)
+	// Use a detached context for Complete/Abort so a client disconnect
+	// doesn't cancel the S3 finalization mid-flight and produce a spurious
+	// Internal error. 60s is generous; CompleteMultipartUpload is typically <5s.
+	completeCtx, completeCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer completeCancel()
+	url, err := mp.Complete(completeCtx)
 	if err != nil {
-		mp.Abort(ctx)
+		abortCtx, abortCancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer abortCancel()
+		mp.Abort(abortCtx)
 		logger("Failed to complete multipart upload: %v", err)
 		return status.Errorf(codes.Internal, "failed to complete upload")
 	}

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -219,6 +219,35 @@ func downloadFile(t *testing.T, email, filename string) (string, error) {
 	return string(data), nil
 }
 
+// downloadFileWithCode is like downloadFile, but also captures the gRPC status code.
+func downloadFileWithCode(t *testing.T, email, filename string) (string, codes.Code, error) {
+	t.Helper()
+	ctx := ctxForUser(email)
+	stream, err := testClient.Download(ctx, &proto.DownloadRequest{Name: filename})
+	if err != nil {
+		if st, ok := status.FromError(err); ok {
+			return "", st.Code(), err
+		}
+		return "", codes.Unknown, err
+	}
+
+	var data []byte
+	for {
+		res, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			if st, ok := status.FromError(err); ok {
+				return string(data), st.Code(), err
+			}
+			return string(data), codes.Unknown, err
+		}
+		data = append(data, res.Data...)
+	}
+	return string(data), codes.OK, nil
+}
+
 func setupTest(t *testing.T) func() {
 	if os.Getenv("TEST_ENV") == "aws-remote" {
 		// Connect to real Fargate server through NLB
@@ -324,6 +353,115 @@ func TestConcurrentUploads(t *testing.T) {
 }
 
 // ─────────────────────────────────────────────────────
+// Test: concurrent uploads followed by concurrent deletes
+// This verifies the file lifecycle for many students, not just access control.
+// ─────────────────────────────────────────────────────
+func TestConcurrentUploadsAndDeletes(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	teacherEmail := getProfessorEmail(t, "CS5010")
+	resetUserDirectory(t, teacherEmail)
+	students := getStudentEmails(t, "CS5010")
+	for _, email := range students {
+		resetUserDirectory(t, email)
+	}
+
+	type uploadResult struct {
+		email    string
+		filename string
+		content  string
+		err      error
+	}
+
+	uploadResults := make(chan uploadResult, len(students))
+	var wg sync.WaitGroup
+
+	for i, email := range students {
+		user := getUser(t, email)
+		folder := user.Colleges["Khoury"].Classes["CS5010"].Folders[0]
+		navigateTo(t, email, "Khoury")
+		navigateTo(t, email, "CS5010")
+		navigateTo(t, email, folder)
+
+		wg.Add(1)
+		go func(i int, email, folder string) {
+			defer wg.Done()
+			filename := fmt.Sprintf("hw_delete_%d.txt", i)
+			content := fmt.Sprintf("homework to delete from student %d", i)
+			err := uploadFile(t, email, filename, content)
+			uploadResults <- uploadResult{
+				email:    email,
+				filename: filename,
+				content:  content,
+				err:      err,
+			}
+		}(i, email, folder)
+	}
+
+	wg.Wait()
+	close(uploadResults)
+
+	var uploaded []uploadResult
+	for r := range uploadResults {
+		if r.err != nil {
+			t.Errorf("%s upload failed: %v", r.email, r.err)
+			continue
+		}
+		uploaded = append(uploaded, r)
+	}
+
+	for _, r := range uploaded {
+		content, err := downloadFile(t, r.email, r.filename)
+		if err != nil {
+			t.Errorf("%s download after upload failed: %v", r.email, err)
+			continue
+		}
+		if content != r.content {
+			t.Errorf("%s download mismatch: got %q want %q", r.email, content, r.content)
+		}
+	}
+
+	deleteResults := make(chan error, len(uploaded))
+	wg = sync.WaitGroup{}
+	for _, r := range uploaded {
+		user := getUser(t, r.email)
+		folder := user.Colleges["Khoury"].Classes["CS5010"].Folders[0]
+		navigateTo(t, r.email, "Khoury")
+		navigateTo(t, r.email, "CS5010")
+		navigateTo(t, r.email, folder)
+
+		wg.Add(1)
+		go func(email, filename string) {
+			defer wg.Done()
+			ctx := ctxForUser(email)
+			_, err := testClient.Delete(ctx, &proto.DeleteRequest{Path: filename})
+			deleteResults <- err
+		}(r.email, r.filename)
+	}
+
+	wg.Wait()
+	close(deleteResults)
+
+	for err := range deleteResults {
+		if err != nil {
+			t.Errorf("delete failed: %v", err)
+		}
+	}
+
+	for _, r := range uploaded {
+		_, code, err := downloadFileWithCode(t, r.email, r.filename)
+		if err == nil {
+			t.Errorf("%s: expected file %s to be gone after delete", r.email, r.filename)
+			continue
+		}
+		if code != codes.NotFound {
+			t.Errorf("%s: expected NotFound after delete, got %s: %v", r.email, code, err)
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────
 // Test: teacher overwrites file while students download concurrently
 // Every student must get a complete valid version, never partial/corrupt
 // ─────────────────────────────────────────────────────
@@ -356,6 +494,7 @@ func TestReadWhileWriting(t *testing.T) {
 		student string
 		content string
 		err     error
+		code    codes.Code
 	}
 
 	var wg sync.WaitGroup
@@ -375,7 +514,7 @@ func TestReadWhileWriting(t *testing.T) {
 		}
 	}()
 
-	// Students download concurrently
+	// Students download concurrently.
 	for _, email := range students {
 		navigateTo(t, email, "Khoury")
 		navigateTo(t, email, "CS5010")
@@ -385,8 +524,8 @@ func TestReadWhileWriting(t *testing.T) {
 		go func(email string) {
 			defer wg.Done()
 			for i := 0; i < 5; i++ {
-				content, err := downloadFile(t, email, "lecture.txt")
-				results <- downloadResult{student: email, content: content, err: err}
+				content, code, err := downloadFileWithCode(t, email, "lecture.txt")
+				results <- downloadResult{student: email, content: content, err: err, code: code}
 				time.Sleep(30 * time.Millisecond)
 			}
 		}(email)
@@ -462,38 +601,61 @@ func TestDeleteDuringDownload(t *testing.T) {
 		code    codes.Code
 	}
 
-	// Phase 1: start downloads from all students concurrently
+	// Phase 1: start downloads from all students concurrently.
 	var wg sync.WaitGroup
 	phase1 := make(chan downloadResult, len(students))
+	started := make(chan struct{}, len(students))
 
 	for _, email := range students {
 		wg.Add(1)
 		go func(email string) {
 			defer wg.Done()
-			content, err := downloadFile(t, email, "handout.txt")
-			r := downloadResult{student: email, size: len(content), err: err}
+			ctx := ctxForUser(email)
+			stream, err := testClient.Download(ctx, &proto.DownloadRequest{Name: "handout.txt"})
 			if err != nil {
+				r := downloadResult{student: email, err: err}
 				if st, ok := status.FromError(err); ok {
 					r.code = st.Code()
 				}
+				started <- struct{}{}
+				phase1 <- r
+				return
 			}
+			started <- struct{}{}
+
+			var data []byte
+			for {
+				res, err := stream.Recv()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					r := downloadResult{student: email, size: len(data), err: err}
+					if st, ok := status.FromError(err); ok {
+						r.code = st.Code()
+					}
+					phase1 <- r
+					return
+				}
+				data = append(data, res.Data...)
+			}
+
+			r := downloadResult{student: email, size: len(data)}
 			phase1 <- r
 		}(email)
 	}
 
-	// Small delay then teacher deletes the file
-	time.Sleep(100 * time.Millisecond)
-	ctx := ctxForUser(teacherEmail)
-	var deleteErr error
-	for attempt := 0; attempt < 3; attempt++ {
-		_, deleteErr = testClient.Delete(ctx, &proto.DeleteRequest{Path: "handout.txt"})
-		if deleteErr == nil {
-			break
+	for i := 0; i < len(students); i++ {
+		select {
+		case <-started:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for downloads to start")
 		}
-		time.Sleep(50 * time.Millisecond)
 	}
-	if deleteErr != nil {
-		t.Fatalf("teacher delete failed after retries: %v", deleteErr)
+
+	ctx := ctxForUser(teacherEmail)
+	if _, deleteErr := testClient.Delete(ctx, &proto.DeleteRequest{Path: "handout.txt"}); deleteErr != nil {
+		t.Fatalf("teacher delete failed: %v", deleteErr)
 	}
 
 	wg.Wait()
@@ -501,13 +663,13 @@ func TestDeleteDuringDownload(t *testing.T) {
 
 	for r := range phase1 {
 		if r.err != nil {
-			// NotFound or Internal are acceptable — depends on whether the delete
-			// landed before the student's metadata lookup or S3 GetObject
-			if r.code == codes.NotFound || r.code == codes.Internal {
-				t.Logf("student %s: got %s during race (acceptable)", r.student, r.code)
-			} else {
-				t.Errorf("student %s: unexpected error: %v", r.student, r.err)
+			// If the delete won the race, the request should fail with NotFound.
+			// Anything else points to a transport or consistency bug.
+			if r.code == codes.NotFound {
+				t.Logf("student %s: got NotFound during race (acceptable)", r.student)
+				continue
 			}
+			t.Errorf("student %s: unexpected race error: %v", r.student, r.err)
 		} else {
 			// If download succeeded, must have gotten the complete file
 			if r.size != len(bigContent) {
@@ -592,6 +754,7 @@ func TestDeleteFolderDuringDownload(t *testing.T) {
 
 	var wg sync.WaitGroup
 	results := make(chan downloadResult, len(students)*3)
+	started := make(chan struct{}, len(students)*3)
 
 	// Each student downloads all 3 files concurrently
 	for _, email := range students {
@@ -600,21 +763,50 @@ func TestDeleteFolderDuringDownload(t *testing.T) {
 			go func(email string, fileIdx int) {
 				defer wg.Done()
 				filename := fmt.Sprintf("notes_%d.txt", fileIdx)
-				content, err := downloadFile(t, email, filename)
-				r := downloadResult{student: email, filename: filename, size: len(content), err: err}
+				ctx := ctxForUser(email)
+				stream, err := testClient.Download(ctx, &proto.DownloadRequest{Name: filename})
 				if err != nil {
+					r := downloadResult{student: email, filename: filename, err: err}
 					if st, ok := status.FromError(err); ok {
 						r.code = st.Code()
 					}
+					started <- struct{}{}
+					results <- r
+					return
 				}
-				results <- r
+				started <- struct{}{}
+
+				var data []byte
+				for {
+					res, err := stream.Recv()
+					if err == io.EOF {
+						break
+					}
+					if err != nil {
+						r := downloadResult{student: email, filename: filename, size: len(data), err: err}
+						if st, ok := status.FromError(err); ok {
+							r.code = st.Code()
+						}
+						results <- r
+						return
+					}
+					data = append(data, res.Data...)
+				}
+				results <- downloadResult{student: email, filename: filename, size: len(data)}
 			}(email, i)
 		}
 	}
 
-	// Teacher deletes the entire folder while downloads are in flight
-	time.Sleep(10 * time.Millisecond)
-	// Navigate teacher back to class root to delete the folder
+	for i := 0; i < len(students)*3; i++ {
+		select {
+		case <-started:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for folder downloads to start")
+		}
+	}
+
+	// Teacher deletes the entire folder while downloads are in flight.
+	// Navigate teacher back to class root to delete the folder.
 	navigateTo(t, teacherEmail, "..")
 	if _, err := testClient.Delete(ctx, &proto.DeleteRequest{Path: "temp_delete_test/"}); err != nil {
 		t.Fatalf("teacher folder delete failed: %v", err)
@@ -627,9 +819,9 @@ func TestDeleteFolderDuringDownload(t *testing.T) {
 	failCount := 0
 	for r := range results {
 		if r.err != nil {
-			if r.code == codes.NotFound || r.code == codes.Internal {
+			if r.code == codes.NotFound {
 				failCount++
-				t.Logf("student %s file %s: %s during race (acceptable)", r.student, r.filename, r.code)
+				t.Logf("student %s file %s: NotFound during race (acceptable)", r.student, r.filename)
 			} else {
 				t.Errorf("student %s file %s: unexpected error: %v", r.student, r.filename, r.err)
 			}

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -425,6 +425,7 @@ func TestConcurrentUploadsAndDeletes(t *testing.T) {
 	deleteResults := make(chan error, len(uploaded))
 	wg = sync.WaitGroup{}
 	for _, r := range uploaded {
+		resetUserDirectory(t, r.email)
 		user := getUser(t, r.email)
 		folder := user.Colleges["Khoury"].Classes["CS5010"].Folders[0]
 		navigateTo(t, r.email, "Khoury")

--- a/server/utils.go
+++ b/server/utils.go
@@ -467,7 +467,8 @@ func (s *server) DeleteS3File(ctx context.Context, s3Key string) error {
 }
 
 // removeFolderFromLists removes a folder and all its subfolders from user and class permission arrays.
-func (s *server) removeFolderFromLists(ctx context.Context, collegeName, className, folderPath string) {
+// It returns an error if cleanup cannot be completed after retries.
+func (s *server) removeFolderFromLists(ctx context.Context, collegeName, className, folderPath string) error {
 	targetPath := strings.TrimSuffix(folderPath, "/")
 	prefix := targetPath + "/"
 
@@ -480,7 +481,7 @@ func (s *server) removeFolderFromLists(ctx context.Context, collegeName, classNa
 		classInfo, err = s.getClassInfo(ctx, className)
 		if err != nil {
 			logger("removeFolderFromLists: failed to get class info: %v", err)
-			return
+			return err
 		}
 
 		newSharedStr := make([]string, 0, len(classInfo.SharedFolders))
@@ -520,7 +521,7 @@ func (s *server) removeFolderFromLists(ctx context.Context, collegeName, classNa
 			continue
 		}
 		logger("removeFolderFromLists: failed to update shared folders: %v", err)
-		break
+		return err
 	}
 
 	// Rebuild every class member's (students, TAs, professor) folders list.
@@ -534,15 +535,16 @@ func (s *server) removeFolderFromLists(ctx context.Context, collegeName, classNa
 		for attempt := 0; attempt < 8; attempt++ {
 			u, err := s.getUser(ctx, memberEmail)
 			if err != nil {
-				break
+				logger("removeFolderFromLists: failed to get user %s: %v", memberEmail, err)
+				return err
 			}
 			college, ok := u.Colleges[collegeName]
 			if !ok {
-				break
+				return fmt.Errorf("removeFolderFromLists: missing college %s for %s", collegeName, memberEmail)
 			}
 			classData, ok := college.Classes[className]
 			if !ok {
-				break
+				return fmt.Errorf("removeFolderFromLists: missing class %s for %s", className, memberEmail)
 			}
 			oldFolders := classData.Folders
 
@@ -586,9 +588,10 @@ func (s *server) removeFolderFromLists(ctx context.Context, collegeName, classNa
 				continue
 			}
 			logger("removeFolderFromLists: failed to update folders for %s: %v", memberEmail, err)
-			break
+			return err
 		}
 	}
+	return nil
 }
 
 func (s *server) DownloadS3File(ctx context.Context, s3Url string) (*s3.GetObjectOutput, error) {

--- a/server/utils.go
+++ b/server/utils.go
@@ -540,11 +540,11 @@ func (s *server) removeFolderFromLists(ctx context.Context, collegeName, classNa
 			}
 			college, ok := u.Colleges[collegeName]
 			if !ok {
-				return fmt.Errorf("removeFolderFromLists: missing college %s for %s", collegeName, memberEmail)
+				break
 			}
 			classData, ok := college.Classes[className]
 			if !ok {
-				return fmt.Errorf("removeFolderFromLists: missing class %s for %s", className, memberEmail)
+				break
 			}
 			oldFolders := classData.Folders
 
@@ -654,16 +654,10 @@ func (s *server) SetCurrentDirectory(ctx context.Context, email string, expected
 			":prev": &types.AttributeValueMemberS{Value: expectedPrev},
 		},
 	}
-	//Ensures that that the directory being read has not changed
-	if expectedPrev == "" {
-		input.ConditionExpression = aws.String(
-			"attribute_not_exists(currentDirectory) OR currentDirectory = :prev",
-		)
-	} else {
-		input.ConditionExpression = aws.String(
-			"attribute_not_exists(currentDirectory) OR currentDirectory = :prev",
-		)
-	}
+	// Ensures the directory hasn't been changed by another session since we last read it
+	input.ConditionExpression = aws.String(
+		"attribute_not_exists(currentDirectory) OR currentDirectory = :prev",
+	)
 	_, err := s.DB.UpdateItem(ctx, input)
 	if err != nil {
 		var condErr *types.ConditionalCheckFailedException


### PR DESCRIPTION
I cleaned up our error handling during file and folder deletions, and added a new load test for upload and delete.

Found an issue in server/main.go where S3 or DynamoDB deletion failures were just being logged while the function continued. Delete and removeFolderFromLists now explicitly return errors and stop execution so we can better analyze our test results.

Added an upload_delete_cycle to load_test.js. It runs 10 VUs for 3 iterations to stress-test the upload/delete path.

By returning errors immediately in the removeFolderFromLists, we risk partial permission updates if a DB request throttles halfway through iterating over class members. Left it synchronous, but we also could consider making this async.